### PR TITLE
adding a SECURITY file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities to security@iohk.io. You will receive a
+response from us within 48 hours. If the issue is confirmed, we will release a patch as soon
+as possible.
+
+Please provide a clear and concise description of the vulnerability, including:
+
+* the affected component(s) and version(s),
+* steps that can be followed to exercise the vulnerability,
+* any workarounds or mitigations
+
+If you have developed any code or utilities that can help demonstrate the suspected
+vulnerability, please mention them in your email but ***DO NOT*** attempt to include them as
+attachments as this may cause your Email to be blocked by spam filters.

--- a/policy/project/README.md
+++ b/policy/project/README.md
@@ -40,6 +40,8 @@ See [the practices section](../../practices/project/index.html) for a broader di
 
 A `SECURITY` document MUST provide security@iohk.io as the contact email for security issues.
 
+Individual projects SHOULD use the [default security file in this repository](https://github.com/input-output-hk/cardano-engineering-handbook/blob/main/SECURITY.md), either by copying it or linking to it.
+
 ### CODE OF CONDUCT
 
 Individual projects SHOULD use the [default Code of Conduct in this repository](https://github.com/input-output-hk/cardano-engineering-handbook/blob/main/CODE-OF-CONDUCT.md), either by copying it or linking to it.


### PR DESCRIPTION
This SECURITY file was [taken](https://github.com/input-output-hk/cardano-node/blob/9cd1f116ec15ec1d992a88a7f6c59e4328a5862d/SECURITY.md) from `cardano-node`, with a slight modification.

The line

```
the affected version(s) of cardano-node,
```

was changed to

```
the affected component(s) and version(s),
```

I am adding the SECURITY file to this repository so that other Cardano repositories can link to it.